### PR TITLE
Add FastAPI backend skeleton for health analysis

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,3 @@
+# ค่า default ใช้ SQLite อยู่ในไฟล์ app.db
+DATABASE_URL=sqlite:///./app.db
+PORT=8000

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,52 @@
+# AI ผู้ช่วยวิเคราะห์อาการ NCD และสุขภาพจิต (Backend)
+
+โปรเจกต์นี้เป็นตัวอย่าง API สำหรับช่วยประเมินอาการเบื้องต้นและติดตามข้อมูลสุขภาพ โดยใช้เทคโนโลยี FastAPI, SQLAlchemy 2.x และ Pydantic v2
+
+## โครงสร้างโดยรวม
+```
+backend/
+  README.md
+  requirements.txt
+  run.sh
+  .env.example
+  app/
+    db.py
+    models.py
+    schemas.py
+    main.py
+    logic/
+      triage.py
+      trends.py
+```
+
+## การเตรียมสภาพแวดล้อม
+
+1. สร้าง virtual environment แล้วติดตั้ง dependency:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+2. ก๊อปปี้ไฟล์ `.env.example` เป็น `.env` แล้วแก้ไขค่า `DATABASE_URL` หากต้องการ (ค่า default คือ SQLite ในไฟล์ `app.db`).
+
+## การรันเซิร์ฟเวอร์
+
+```bash
+./run.sh
+```
+
+สคริปต์จะโหลดตัวแปรจาก `.env` (ถ้ามี) แล้วสั่ง `uvicorn` ให้รันแอป FastAPI
+
+## การย้ายโครงสร้างฐานข้อมูล
+
+ตัวอย่างนี้ใช้ SQLite และสร้างตารางอัตโนมัติเมื่อแอปรันครั้งแรกผ่าน `app/models.py`. ในระบบจริงควรใช้เครื่องมือ migration เช่น Alembic.
+
+## Endpoints หลัก
+
+* `GET /health` ตรวจสอบสถานะ API
+* `POST /analyze` ประเมินระดับความเร่งด่วนจากข้อมูลอาการ
+* `POST /observe` บันทึกข้อมูล observation (ค่าชีววัด, แบบประเมิน ฯลฯ)
+* `POST /trend` วิเคราะห์แนวโน้มค่าชีววัด/คะแนนย้อนหลัง
+
+> **หมายเหตุ:** ระบบนี้เป็นเพียงตัวช่วยวิเคราะห์เบื้องต้น ไม่ใช่การวินิจฉัยทางการแพทย์
+

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,0 +1,34 @@
+"""Database configuration module."""
+from __future__ import annotations
+
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import DeclarativeBase, sessionmaker
+
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./app.db")
+
+connect_args = {}
+if DATABASE_URL.startswith("sqlite"):
+    connect_args = {"check_same_thread": False}
+
+engine = create_engine(DATABASE_URL, connect_args=connect_args, future=True)
+
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+
+
+class Base(DeclarativeBase):
+    """Declarative base class for SQLAlchemy models."""
+
+
+def get_db():
+    """Provide a transactional scope around a series of operations."""
+    db = SessionLocal()
+    try:
+        yield db
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()

--- a/backend/app/logic/trends.py
+++ b/backend/app/logic/trends.py
@@ -1,0 +1,59 @@
+"""Utility functions for analyzing trends of observations."""
+from __future__ import annotations
+
+from datetime import date
+from collections.abc import Sequence
+from typing import List, Tuple
+
+
+def ewma(values: Sequence[float], alpha: float = 0.3) -> List[float]:
+    """Exponential weighted moving average."""
+    if not values:
+        return []
+
+    smoothed: List[float] = []
+    current = values[0]
+    smoothed.append(current)
+    for value in values[1:]:
+        current = alpha * value + (1 - alpha) * current
+        smoothed.append(current)
+    return smoothed
+
+
+def linear_slope(points: Sequence[Tuple[date, float]]) -> float:
+    """Compute the slope per day using ordinary least squares."""
+    if len(points) < 2:
+        return 0.0
+
+    x_values = [(p[0] - points[0][0]).days for p in points]
+    y_values = [p[1] for p in points]
+
+    x_mean = sum(x_values) / len(x_values)
+    y_mean = sum(y_values) / len(y_values)
+
+    numerator = sum((x - x_mean) * (y - y_mean) for x, y in zip(x_values, y_values))
+    denominator = sum((x - x_mean) ** 2 for x in x_values)
+
+    if denominator == 0:
+        return 0.0
+
+    return numerator / denominator
+
+
+def interpret_trend(metric: str, slope: float) -> str:
+    """Provide a qualitative interpretation based on slope."""
+    threshold = 0.1
+    if slope <= -threshold:
+        return "ดีขึ้น"
+    if slope >= threshold:
+        return "แย่ลง"
+    return "ทรงตัว"
+
+
+def confidence_from_points(points: Sequence) -> str:
+    count = len(points)
+    if count >= 8:
+        return "สูง"
+    if count >= 4:
+        return "กลาง"
+    return "ต่ำ"

--- a/backend/app/logic/triage.py
+++ b/backend/app/logic/triage.py
@@ -1,0 +1,78 @@
+"""Triage business logic."""
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+
+def triage_level_from_inputs(payload: Dict) -> Tuple[str, List[str], str]:
+    """Return triage level, actions, and rationale based on payload."""
+    actions: List[str] = []
+    rationale_parts: List[str] = []
+    triage_level = "เขียว"
+
+    bp_sys = payload.get("bp_sys")
+    bp_dia = payload.get("bp_dia")
+    glucose = payload.get("glucose")
+    self_harm = payload.get("self_harm") or payload.get("red_flag_answers", {}).get("self_harm")
+
+    if self_harm:
+        triage_level = "แดง"
+        actions.extend([
+            "โทรหาสายด่วนสุขภาพจิต 1323 หรือพบแพทย์ทันที",
+            "อย่าอยู่ลำพัง ขอความช่วยเหลือจากคนใกล้ชิด",
+        ])
+        rationale_parts.append("มีความเสี่ยงทำร้ายตนเอง")
+
+    if bp_sys is not None and bp_dia is not None and bp_sys >= 180 and bp_dia >= 120:
+        triage_level = "แดง"
+        actions.extend([
+            "ไปห้องฉุกเฉินทันที",
+            "หลีกเลี่ยงการขับรถเอง",
+        ])
+        rationale_parts.append("ความดันโลหิตเข้าเกณฑ์วิกฤต")
+
+    if glucose is not None and glucose >= 300:
+        if triage_level != "แดง":
+            triage_level = "ส้ม"
+        actions.append("ตรวจสอบระดับน้ำตาลและพบแพทย์โดยเร็ว")
+        rationale_parts.append("ระดับน้ำตาลสูงกว่าปกติ")
+
+    if not rationale_parts:
+        triage_level = "เหลือง" if payload.get("severity", 0) >= 5 else "เขียว"
+        if triage_level == "เหลือง":
+            actions.append("นัดพบแพทย์ภายใน 24-48 ชั่วโมง")
+            rationale_parts.append("ระดับอาการปานกลาง")
+        else:
+            actions.append("ติดตามอาการและดูแลตนเอง")
+            rationale_parts.append("ไม่พบสัญญาณอันตรายเร่งด่วน")
+
+    rationale = "; ".join(dict.fromkeys(rationale_parts)) or "ประเมินไม่พบข้อมูลเพียงพอ"
+    actions = list(dict.fromkeys(actions))
+    return triage_level, actions, rationale
+
+
+def mock_condition_hints(payload: Dict) -> List[str]:
+    """Provide a naive list of possible conditions for demonstration."""
+    hints: List[str] = []
+    domain = payload.get("domain")
+    symptom = payload.get("primary_symptom", "").lower()
+
+    if domain == "NCD":
+        if "เวียน" in symptom or "หน้ามืด" in symptom:
+            hints.append("ตรวจระดับน้ำตาลและความดัน")
+        if payload.get("bp_sys") and payload.get("bp_sys") > 140:
+            hints.append("อาจเกี่ยวข้องกับความดันโลหิตสูง")
+        if payload.get("glucose") and payload.get("glucose") > 140:
+            hints.append("ติดตามเบาหวาน")
+    elif domain == "MH":
+        if payload.get("phq9") and payload["phq9"] >= 10:
+            hints.append("อาจมีภาวะซึมเศร้าระดับปานกลาง")
+        if payload.get("gad7") and payload["gad7"] >= 10:
+            hints.append("อาจมีความวิตกกังวลสูง")
+        if payload.get("isi") and payload["isi"] >= 15:
+            hints.append("ภาวะนอนไม่หลับระดับปานกลาง")
+
+    if not hints:
+        hints.append("ควรติดตามอาการเพิ่มเติม")
+
+    return hints

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,106 @@
+"""FastAPI application entrypoint."""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import List
+
+from fastapi import Depends, FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from .db import get_db
+from .logic.trends import confidence_from_points, ewma, interpret_trend, linear_slope
+from .logic.triage import mock_condition_hints, triage_level_from_inputs
+from . import models, schemas
+
+
+app = FastAPI(title="AI Health Assistant API")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/health")
+def health_check():
+    return {"status": "ok"}
+
+
+@app.post("/observe")
+def create_observation(payload: schemas.ObservationIn, db: Session = Depends(get_db)):
+    episode = db.get(models.Episode, payload.episode_id)
+    if episode is None:
+        raise HTTPException(status_code=404, detail="Episode not found")
+
+    observation_data = payload.model_dump()
+    observation = models.Observation(**observation_data)
+    db.add(observation)
+    db.flush()
+
+    return {
+        "id": observation.id,
+        "episode_id": observation.episode_id,
+        "date": observation.date,
+        "data": {k: getattr(observation, k) for k in observation_data if k not in {"episode_id", "date"}},
+    }
+
+
+@app.post("/analyze", response_model=schemas.AnalyzeOut)
+def analyze(payload: schemas.AnalyzeIn):
+    data = payload.model_dump()
+    triage_level, actions, rationale = triage_level_from_inputs(data)
+    hints = mock_condition_hints(data)
+    return schemas.AnalyzeOut(
+        triage_level=triage_level,
+        actions=actions,
+        rationale=rationale,
+        hints=hints,
+    )
+
+
+@app.post("/trend", response_model=schemas.TrendOut)
+def analyze_trend(payload: schemas.TrendRequest, db: Session = Depends(get_db)):
+    stmt = select(models.Observation).where(models.Observation.episode_id == payload.episode_id)
+    if payload.days:
+        start_date = date.today() - timedelta(days=payload.days)
+        stmt = stmt.where(models.Observation.date >= start_date)
+
+    stmt = stmt.order_by(models.Observation.date.asc())
+    observations: List[models.Observation] = db.execute(stmt).scalars().all()
+
+    metric_values = []
+    points = []
+    for obs in observations:
+        value = getattr(obs, payload.metric)
+        if value is None:
+            continue
+        metric_values.append(value)
+        points.append((obs.date, value))
+
+    slope = linear_slope(points) if points else 0.0
+    trend_label = interpret_trend(payload.metric, slope)
+    ewma_values = ewma(metric_values) if metric_values else []
+
+    response_points = [schemas.TrendPoint(date=p[0], value=p[1]) for p in points]
+    confidence = confidence_from_points(points)
+
+    return schemas.TrendOut(
+        metric=payload.metric,
+        points=response_points,
+        ewma=ewma_values,
+        slope_per_day=slope,
+        trend=trend_label,
+        confidence=confidence,
+    )
+
+
+@app.on_event("startup")
+def ensure_tables_exist():
+    # Importing models already creates tables via metadata.create_all
+    from . import models  # noqa: F401
+
+    _ = models  # keep reference for linters

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,62 @@
+"""SQLAlchemy ORM models."""
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import List, Optional
+
+from sqlalchemy import Date, DateTime, Enum, Float, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .db import Base, engine
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    dob: Mapped[Optional[date]] = mapped_column(Date, nullable=True)
+    sex: Mapped[Optional[str]] = mapped_column(String(1), nullable=True)
+    chronic_conditions: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    allergies: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    meds: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    habits: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    episodes: Mapped[List["Episode"]] = relationship(back_populates="user", cascade="all, delete-orphan")
+
+
+class Episode(Base):
+    __tablename__ = "episodes"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    domain: Mapped[str] = mapped_column(Enum("NCD", "MH", name="episode_domain"), nullable=False)
+    started_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    primary_symptom: Mapped[str] = mapped_column(String(255), nullable=False)
+    severity_0_10: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    notes: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    user: Mapped[User] = relationship(back_populates="episodes")
+    observations: Mapped[List["Observation"]] = relationship(back_populates="episode", cascade="all, delete-orphan")
+
+
+class Observation(Base):
+    __tablename__ = "observations"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    episode_id: Mapped[int] = mapped_column(ForeignKey("episodes.id", ondelete="CASCADE"), nullable=False, index=True)
+    date: Mapped[date] = mapped_column(Date, nullable=False)
+    bp_sys: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    bp_dia: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    hr: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    weight: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    waist: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    glucose: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    phq9: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    gad7: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    isi: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+
+    episode: Mapped[Episode] = relationship(back_populates="observations")
+
+
+# Create tables when module is imported
+Base.metadata.create_all(bind=engine)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,0 +1,74 @@
+"""Pydantic schemas for request and response models."""
+from __future__ import annotations
+
+from datetime import date
+from typing import Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class ObservationIn(BaseModel):
+    episode_id: int
+    date: date = Field(description="Date of the observation")
+    bp_sys: Optional[float] = None
+    bp_dia: Optional[float] = None
+    hr: Optional[float] = None
+    weight: Optional[float] = None
+    waist: Optional[float] = None
+    glucose: Optional[float] = None
+    phq9: Optional[float] = None
+    gad7: Optional[float] = None
+    isi: Optional[float] = None
+
+
+class AnalyzeIn(BaseModel):
+    age: int
+    sex: Literal["M", "F", "O"]
+    domain: Literal["NCD", "MH"]
+    primary_symptom: str
+    duration_days: Optional[int] = None
+    bp_sys: Optional[float] = None
+    bp_dia: Optional[float] = None
+    glucose: Optional[float] = None
+    phq9: Optional[float] = None
+    gad7: Optional[float] = None
+    isi: Optional[float] = None
+    red_flag_answers: Dict[str, bool] = Field(default_factory=dict)
+    self_harm: Optional[bool] = None
+
+
+class AnalyzeOut(BaseModel):
+    triage_level: Literal["เขียว", "เหลือง", "ส้ม", "แดง"]
+    actions: List[str]
+    rationale: str
+    hints: List[str]
+
+
+class TrendRequest(BaseModel):
+    episode_id: int
+    metric: Literal[
+        "bp_sys",
+        "bp_dia",
+        "hr",
+        "weight",
+        "waist",
+        "glucose",
+        "phq9",
+        "gad7",
+        "isi",
+    ]
+    days: Optional[int] = Field(default=30, ge=1, description="Number of days to look back")
+
+
+class TrendPoint(BaseModel):
+    date: date
+    value: float
+
+
+class TrendOut(BaseModel):
+    metric: str
+    points: List[TrendPoint]
+    ewma: Optional[List[float]]
+    slope_per_day: float
+    trend: Literal["ดีขึ้น", "ทรงตัว", "แย่ลง"]
+    confidence: Literal["ต่ำ", "กลาง", "สูง"]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,5 @@
+fastapi>=0.103
+uvicorn[standard]>=0.22
+SQLAlchemy>=2.0
+pydantic>=2.0
+python-dotenv>=1.0

--- a/backend/run.sh
+++ b/backend/run.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -f .env ]; then
+  set -a
+  source .env
+  set +a
+fi
+
+exec uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}


### PR DESCRIPTION
## Summary
- scaffold backend project structure for the AI health assistant API
- implement SQLAlchemy models, Pydantic schemas, and business logic for triage and trends
- expose FastAPI endpoints for health check, observation logging, triage analysis, and metric trends

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68d9e38f029c83269813ebe2c81271fa