### PR TITLE
Add severity score field and triage test coverage

### DIFF
--- a/backend/app/logic/triage.py
+++ b/backend/app/logic/triage.py
@@ -38,7 +38,10 @@ def triage_level_from_inputs(payload: Dict) -> Tuple[str, List[str], str]:
         rationale_parts.append("ระดับน้ำตาลสูงกว่าปกติ")
 
     if not rationale_parts:
-        triage_level = "เหลือง" if payload.get("severity", 0) >= 5 else "เขียว"
+        severity_score = payload.get("severity_0_10")
+        if severity_score is None:
+            severity_score = 0
+        triage_level = "เหลือง" if severity_score >= 5 else "เขียว"
         if triage_level == "เหลือง":
             actions.append("นัดพบแพทย์ภายใน 24-48 ชั่วโมง")
             rationale_parts.append("ระดับอาการปานกลาง")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -33,6 +33,12 @@ class AnalyzeIn(BaseModel):
     phq9: Optional[float] = None
     gad7: Optional[float] = None
     isi: Optional[float] = None
+    severity_0_10: Optional[int] = Field(
+        default=None,
+        ge=0,
+        le=10,
+        description="Self-reported symptom severity on a 0-10 scale",
+    )
     red_flag_answers: Dict[str, bool] = Field(default_factory=dict)
     self_harm: Optional[bool] = None
 

--- a/backend/app/tests/test_analyze.py
+++ b/backend/app/tests/test_analyze.py
@@ -1,0 +1,29 @@
+"""Tests for the /analyze endpoint."""
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+from backend.app.main import app
+
+
+client = TestClient(app)
+
+
+def test_moderate_severity_promotes_to_yellow():
+    payload = {
+        "age": 30,
+        "sex": "F",
+        "domain": "NCD",
+        "primary_symptom": "ปวดหัว",
+        "severity_0_10": 6,
+        "red_flag_answers": {},
+    }
+
+    response = client.post("/analyze", json=payload)
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["triage_level"] == "เหลือง"
+    assert "นัดพบแพทย์ภายใน 24-48 ชั่วโมง" in data["actions"]
+    assert "ระดับอาการปานกลาง" in data["rationale"]


### PR DESCRIPTION
## Summary
- add a `severity_0_10` field to the analyze request schema
- update triage logic to reference the severity score when promoting to yellow
- cover the `/analyze` endpoint with a test that asserts moderate severity yields a yellow triage level

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9fb08c218832699742e9895b39a23