### PR TITLE
Require explicit secrets configuration

### DIFF
--- a/my-ai-backend/README.md
+++ b/my-ai-backend/README.md
@@ -18,13 +18,17 @@ FastAPI backend that analyzes chronic non-communicable disease (NCD) and mental 
 - Docker and Docker Compose, or Python 3.11 with virtualenv.
 
 ### Environment Variables
-Copy `.env.example` to `.env` and update secrets:
+Environment variables are required for startup. Use `.env.example` as
+documentation, copy it to `.env`, and replace every placeholder with real
+values:
 
 ```bash
 cp .env.example .env
 ```
 
-Key variables:
+The application only loads `.env` (plus any variables already present in the
+environment); missing secrets will raise a clear error at startup. Key
+variables:
 - `DATABASE_URL`: e.g. `postgresql+psycopg2://postgres:postgres@db:5432/healthai`
 - `JWT_SECRET_KEY` / `JWT_REFRESH_SECRET_KEY`: long random strings.
 - `RATE_LIMIT_CALLS` & `RATE_LIMIT_PERIOD`: integer calls per period (seconds).

--- a/my-ai-backend/app/settings.py
+++ b/my-ai-backend/app/settings.py
@@ -2,15 +2,15 @@
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import lru_cache
 from typing import Optional
 
 from dotenv import load_dotenv
 
-# Load env files (example first to provide defaults, then actual values)
-load_dotenv(".env.example", override=False)
-load_dotenv(".env", override=True)
+# Load local overrides when available. The `.env.example` file is documentation
+# only and is no longer loaded automatically.
+load_dotenv(".env", override=False)
 
 
 def _get_bool(value: Optional[str], default: bool) -> bool:
@@ -26,6 +26,18 @@ def _get_int(value: Optional[str], default: int) -> int:
         return default
 
 
+def _require_env(name: str) -> str:
+    """Return the required environment variable or raise a helpful error."""
+
+    value = os.getenv(name, "").strip()
+    if not value:
+        raise RuntimeError(
+            f"Environment variable '{name}' is required but not set. "
+            "Define it via real environment variables or a local .env file."
+        )
+    return value
+
+
 @dataclass
 class Settings:
     """Simple settings container."""
@@ -37,8 +49,8 @@ class Settings:
 
     database_url: str = os.getenv("DATABASE_URL", "sqlite:///./test.db")
 
-    jwt_secret_key: str = os.getenv("JWT_SECRET_KEY", "change-me")
-    jwt_refresh_secret_key: str = os.getenv("JWT_REFRESH_SECRET_KEY", "change-me-too")
+    jwt_secret_key: str = field(default_factory=lambda: _require_env("JWT_SECRET_KEY"))
+    jwt_refresh_secret_key: str = field(default_factory=lambda: _require_env("JWT_REFRESH_SECRET_KEY"))
     jwt_algorithm: str = os.getenv("JWT_ALGORITHM", "HS256")
     access_token_expire_minutes: int = _get_int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES"), 15)
     refresh_token_expire_minutes: int = _get_int(os.getenv("REFRESH_TOKEN_EXPIRE_MINUTES"), 60 * 24 * 30)

--- a/my-ai-backend/docker-compose.yml
+++ b/my-ai-backend/docker-compose.yml
@@ -3,7 +3,6 @@ services:
   api:
     build: .
     env_file:
-      - .env.example
       - .env
     ports:
       - "8000:8000"


### PR DESCRIPTION
## Summary
- load only real environment variables and a local .env file, dropping implicit .env.example defaults
- require JWT secret environment variables and surface a clear error when missing
- update documentation and docker-compose configuration to reflect the new loading behavior

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'backend')*


------
https://chatgpt.com/codex/tasks/task_e_68da6ae8a1c88326b1fc89301c50b780